### PR TITLE
2000年-2002年の体育の日欠如バグの修正（その2）

### DIFF
--- a/jpholiday/jpholiday.py
+++ b/jpholiday/jpholiday.py
@@ -145,7 +145,7 @@ def _holiday_name(date, search_national_holiday=True):
 	elif date.month == 10:
 		if date.year >= 1966 and date.year <= 1999 and date.day == 10:
 			name = '体育の日'
-		elif date.year >= 2003 and date.year <= 2019 and date.day == _week_day(date, 2, 1).day:
+		elif date.year >= 2000 and date.year <= 2019 and date.day == _week_day(date, 2, 1).day:
 			name = '体育の日'
 		# 2020: 国民の祝日に関する法律の一部を改正する法律(平成30年法律第57号)
 		#       国民の祝日に関する法律(昭和23年法律第178号)の特例


### PR DESCRIPTION
2020年対応時に、2000年-2002年の体育の日が再度欠如してしまったようなので、その修正になります。

何卒よろしくお願いいたします。
