### PR TITLE
国民の休日クラスの名前を修正

### DIFF
--- a/jpholiday/holiday.py
+++ b/jpholiday/holiday.py
@@ -333,6 +333,9 @@ class TransferHoliday(registry.BaseHoliday):
                 if holiday.__class__.__name__ == self.__class__.__name__:
                     continue
 
+                if isinstance(holiday, NationalHoliday):
+                    continue
+
                 if isinstance(holiday, registry.OriginalHoliday):
                     continue
 
@@ -350,6 +353,9 @@ class TransferHoliday(registry.BaseHoliday):
             if holiday.__class__.__name__ == self.__class__.__name__:
                 continue
 
+            if isinstance(holiday, NationalHoliday):
+                continue
+
             if isinstance(holiday, registry.OriginalHoliday):
                 continue
 
@@ -359,7 +365,7 @@ class TransferHoliday(registry.BaseHoliday):
 
 
 # 国民の休日
-class TransferHoliday(registry.BaseHoliday):
+class NationalHoliday(registry.BaseHoliday):
     def _is_holiday(self, date):
 
         result = {


### PR DESCRIPTION
国民の休日と振替休日のクラス名がTransferHolidayで同じでした。
最初は間違いかと思いましたが、上記２クラス間での再起呼び出しを防ぐため、意図して同じクラス名にしたものと思います。ただ、初見だとその意図がわかりませんし、本来はわかりやすいクラス名をつけたいはずですので、そのように修正するPull Requestです。
自動テストが通ることは確認しています。