### PR TITLE
Update package discovery by using find_packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import re
 from codecs import open
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open(os.path.join('jpholiday', '__init__.py'), 'r', encoding='utf8') as f:
     version = re.compile(
@@ -10,7 +10,7 @@ with open(os.path.join('jpholiday', '__init__.py'), 'r', encoding='utf8') as f:
 
 setup(
     name='jpholiday',
-    packages=['jpholiday'],
+    packages=find_packages(include=['jpholiday', 'jpholiday.*']),
     version=version,
     license='MIT License',
     platforms=['POSIX', 'Windows', 'Unix', 'MacOS'],


### PR DESCRIPTION
Ver 1.0.0 より import が失敗していた件につきまして、setup.py を修正し動作検証いたしました。

#35 

## 変更点

setup.py における setup 関数の packages 引数を修正

## 動作確認

修正後の `python setup.py sdist bdist_wheel` の結果に cache, checker, model, registry パッケージが含まれていることを確認

### 修正前

```
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ git rev-parse HEAD
e6e7dc505e305befcda2cc01512181f747a6d695
$ pipenv run python setup.py sdist bdist_wheel
（略）
$ pushd dist
$ unzip jpholiday-1.0.0-py3-none-any.whl
Archive:  jpholiday-1.0.0-py3-none-any.whl
  inflating: jpholiday/__init__.py
  inflating: jpholiday/exception.py
  inflating: jpholiday/functions.py
  inflating: jpholiday/jpholiday.py
  inflating: jpholiday-1.0.0.data/data/README.md
  inflating: jpholiday-1.0.0.dist-info/licenses/LICENSE
  inflating: jpholiday-1.0.0.dist-info/METADATA
  inflating: jpholiday-1.0.0.dist-info/WHEEL
  inflating: jpholiday-1.0.0.dist-info/top_level.txt
  inflating: jpholiday-1.0.0.dist-info/RECORD
```

### 修正後

```
$ git checkout fix-packages-in-setup.py
Switched to branch 'fix-packages-in-setup.py'
$ git rev-parse HEAD
122c5b93301176148319305f847e1d7b096220af
$ rm -rf dist/
$ pipenv run python setup.py sdist bdist_wheel
（略）
$ pushd dist
/d/workspace/jpholiday/dist /d/workspace/jpholiday
$ unzip jpholiday-1.0.0-py3-none-any.whl
Archive:  jpholiday-1.0.0-py3-none-any.whl
  inflating: jpholiday/__init__.py
  inflating: jpholiday/exception.py
  inflating: jpholiday/functions.py
  inflating: jpholiday/jpholiday.py
  inflating: jpholiday/cache/__init__.py
  inflating: jpholiday/cache/in_memory.py
  inflating: jpholiday/cache/interface.py
  inflating: jpholiday/checker/__init__.py
  inflating: jpholiday/checker/checker.py
  inflating: jpholiday/checker/interface.py
  inflating: jpholiday/checker/utils.py
  inflating: jpholiday/model/__init__.py
  inflating: jpholiday/model/holiday.py
  inflating: jpholiday/registy/__init__.py
  inflating: jpholiday/registy/interface.py
  inflating: jpholiday/registy/registry.py
  inflating: jpholiday-1.0.0.data/data/README.md
  inflating: jpholiday-1.0.0.dist-info/licenses/LICENSE
  inflating: jpholiday-1.0.0.dist-info/METADATA
  inflating: jpholiday-1.0.0.dist-info/WHEEL
  inflating: jpholiday-1.0.0.dist-info/top_level.txt
  inflating: jpholiday-1.0.0.dist-info/RECORD
$ tar xvzf jpholiday-1.0.0.tar.gz
jpholiday-1.0.0/
jpholiday-1.0.0/LICENSE
jpholiday-1.0.0/PKG-INFO
jpholiday-1.0.0/README.md
jpholiday-1.0.0/jpholiday/
jpholiday-1.0.0/jpholiday/__init__.py
jpholiday-1.0.0/jpholiday/cache/
jpholiday-1.0.0/jpholiday/cache/__init__.py
jpholiday-1.0.0/jpholiday/cache/in_memory.py
jpholiday-1.0.0/jpholiday/cache/interface.py
jpholiday-1.0.0/jpholiday/checker/
jpholiday-1.0.0/jpholiday/checker/__init__.py
jpholiday-1.0.0/jpholiday/checker/checker.py
jpholiday-1.0.0/jpholiday/checker/interface.py
jpholiday-1.0.0/jpholiday/checker/utils.py
jpholiday-1.0.0/jpholiday/exception.py
jpholiday-1.0.0/jpholiday/functions.py
jpholiday-1.0.0/jpholiday/jpholiday.py
jpholiday-1.0.0/jpholiday/model/
jpholiday-1.0.0/jpholiday/model/__init__.py
jpholiday-1.0.0/jpholiday/model/holiday.py
jpholiday-1.0.0/jpholiday/registy/
jpholiday-1.0.0/jpholiday/registy/__init__.py
jpholiday-1.0.0/jpholiday/registy/interface.py
jpholiday-1.0.0/jpholiday/registy/registry.py
jpholiday-1.0.0/jpholiday.egg-info/
jpholiday-1.0.0/jpholiday.egg-info/PKG-INFO
jpholiday-1.0.0/jpholiday.egg-info/SOURCES.txt
jpholiday-1.0.0/jpholiday.egg-info/dependency_links.txt
jpholiday-1.0.0/jpholiday.egg-info/top_level.txt
jpholiday-1.0.0/setup.cfg
jpholiday-1.0.0/setup.py
jpholiday-1.0.0/tests/
jpholiday-1.0.0/tests/test_basic.py
jpholiday-1.0.0/tests/test_class.py
jpholiday-1.0.0/tests/test_datetime.py
jpholiday-1.0.0/tests/test_exception.py
jpholiday-1.0.0/tests/test_year_1971.py
（略）
```


